### PR TITLE
feat(socks): free-tier relay-aware SOCKS client w/ plug-and-play fallbacks

### DIFF
--- a/GCP.md
+++ b/GCP.md
@@ -1,0 +1,157 @@
+# GCP Relay Setup
+
+## Overview
+
+FlareProx can now fall back to a relay that you host on Google Cloud whenever a Cloudflare Worker cannot reach a Cloudflare-managed destination. The relay reuses the same WebSocket handshake as the worker, so no application changes are required—just deploy the relay, note its URL and credentials, then enable it in `flareprox.json` under `client.relay`.
+
+```
+"client": {
+  "relay": {
+    "enabled": true,
+    "url": "ws://YOUR_RELAY_HOSTNAME:8080",
+    "auth_token": "Bearer YOUR_SHARED_TOKEN",
+    "socks_password": "same-password-used-by-worker"
+  }
+}
+```
+
+> **Tips:**
+> - Set the relay `socks_password` to match the worker password so the same credential works everywhere.
+> - Use `ws://` for plaintext listeners (e.g., a VM without TLS) and `wss://` when you terminate TLS in front of the relay (Cloud Run, HTTPS load balancer, etc.).
+
+---
+
+## Option 1 – Compute Engine VM
+
+1. **Provision the VM**
+   - Choose a lightweight image (e.g., `debian-12` or `ubuntu-22.04`).
+   - Expose TCP port `8080` (or any port you plan to bind) in the firewall.
+
+2. **Install dependencies**
+   ```bash
+   sudo apt-get update
+   sudo apt-get install -y python3 python3-venv git
+   python3 -m venv ~/relay-env
+   source ~/relay-env/bin/activate
+   pip install --upgrade pip
+   pip install websockets
+   ```
+
+3. **Deploy the relay**
+   - Copy `gcp_relay.py` to the VM (e.g., via `git clone` of this repository or `scp`).
+   - Run the relay with your chosen password and optional auth token:
+     ```bash
+     source ~/relay-env/bin/activate
+     python3 gcp_relay.py --host 0.0.0.0 --port 8080 \
+       --password "YOUR_SHARED_PASSWORD" \
+       --auth-token "Bearer YOUR_SHARED_TOKEN"
+     ```
+   - Keep the process running with `tmux`, `screen`, or a systemd service.
+
+4. **Record the URL**
+   - Point a DNS record to the VM or note its external IP: `ws://YOUR_HOST:8080` (use `wss://` only if you terminate TLS in front of the relay).
+
+---
+
+## Option 2 – Cloud Run (Container)
+
+### Prerequisites
+
+1. Access your authorized [Google Cloud Shell](https://shell.cloud.google.com/?hl=en_US&fromcloudshell=true&show=terminal)
+2. Pick/create a project and save its ID for the commands below.
+3. Configure defaults (replace `PROJECT_ID` and `REGION`, e.g., `us-central1`):
+   ```bash
+   gcloud config set project PROJECT_ID
+   gcloud config set run/region REGION
+   ```
+4. Enable the required services (one-time per project):
+   ```bash
+   gcloud services enable run.googleapis.com cloudbuild.googleapis.com artifactregistry.googleapis.com
+   ```
+
+### Step 1 – Prepare a build context
+
+From your development machine (where this repo lives):
+```bash
+mkdir -p cloud-run-relay && cd cloud-run-relay
+cp /path/to/repo/gcp_relay.py .
+cat <<'EOF' > Dockerfile
+FROM python:3.11-slim
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY gcp_relay.py ./
+RUN pip install --no-cache-dir websockets
+CMD ["python", "gcp_relay.py"]
+EOF
+```
+
+### Step 2 – Build and publish the container
+
+Cloud Run now prefers Artifact Registry repositories. Create one (once per project), then build:
+```bash
+gcloud artifacts repositories create flareprox-relay-repo \
+  --repository-format docker \
+  --location REGION \
+  --description "Relay images"
+
+gcloud builds submit --tag REGION-docker.pkg.dev/PROJECT_ID/flareprox-relay-repo/flareprox-relay:latest
+```
+
+### Step 3 – Deploy to Cloud Run
+
+```bash
+gcloud run deploy flareprox-relay \
+  --image REGION-docker.pkg.dev/PROJECT_ID/flareprox-relay-repo/flareprox-relay:latest \
+  --platform managed \
+  --allow-unauthenticated \
+  --set-env-vars FLAREPROX_RELAY_PASSWORD=YOUR_SHARED_PASSWORD,FLAREPROX_RELAY_TOKEN="Bearer YOUR_SHARED_TOKEN"
+```
+
+- Cloud Run injects the port via `$PORT`; `gcp_relay.py` reads it automatically.
+- The deploy command prints a service URL (e.g., `https://relay-xyz.a.run.app`). Use the `wss://` form of that URL inside `flareprox.json`.
+- You can re-run the deploy command whenever you push a new image tag.
+
+### Step 4 – Verify the service
+
+1. Fetch the URL anytime:
+   ```bash
+   gcloud run services describe flareprox-relay --format='value(status.url)'
+   ```
+2. (Optional) Restrict ingress via:
+   ```bash
+   gcloud run services update-traffic flareprox-relay --ingress internal-and-cloud-load-balancing
+   ```
+   Pair this with Cloud Armor or Identity-Aware Proxy if you need more control.
+
+Remember to keep `FLAREPROX_RELAY_PASSWORD`/`TOKEN` strong—Cloud Run treats them like environment variables, and you can rotate them with `gcloud run services update`.
+
+---
+
+## Configure FlareProx Client
+
+1. Open `flareprox.json` (or your chosen config file).
+2. In the `client` section, set:
+   ```json
+   "relay": {
+     "enabled": true,
+   "url": "ws://relay.example.com:8080",
+     "auth_token": "Bearer super-secret-token",
+     "socks_password": "generated-socks-password"
+   }
+   ```
+3. Optionally adjust `client.handshake_timeout` (default 5 seconds) if your relay sits behind high-latency networks.
+4. Restart any running local SOCKS listeners. FlareProx will now fall back to the relay whenever the worker reports `cloudflare-blocked`.
+
+---
+
+## Verifying the Fallback
+
+1. Run `python3 flareprox.py socks --bind 127.0.0.1`.
+2. Access a Cloudflare-hosted site through the SOCKS proxy.
+3. When the worker declines the target, the CLI will log a message similar to:
+   ```
+   flareprox-123: fallback to relay for target.example.com:443 (Target served by Cloudflare IP range)
+   ```
+4. Confirm the connection succeeds and packets egress from your GCP relay IP (use `https://ifconfig.me/ip`).
+
+If the relay isn’t reachable, FlareProx will return a SOCKS failure to the client—double-check firewall rules, TLS certificates, and credentials.

--- a/flareprox.example.json
+++ b/flareprox.example.json
@@ -1,0 +1,34 @@
+{
+  "cloudflare": {
+    "api_token": "your_cloudflare_api_token_here",
+    "account_id": "your_cloudflare_account_id_here"
+  },
+  "worker": {
+    "socks_password": "FLAREPROX_RELAY_PASSWORD",
+    "auth_token": "",
+    "compatibility_date": "2023-09-04",
+    "compatibility_flags": [
+      "nodejs_compat"
+    ],
+    "mode": "socks"
+  },
+  "client": {
+    "bind_host": "0.0.0.0",
+    "base_port": 1080,
+    "profiles": [],
+    "auto_random_ports": false,
+    "cf_override_ip": "",
+    "cf_hostnames": [
+      "ifconfig.io"
+    ],
+    "handshake_timeout": 2.0,
+    "relay": {
+      "enabled": true,
+      "url": "wss://flareprox-relay-zzzzz-uw.a.run.app",
+      "auth_token": "",
+      "socks_password": "FLAREPROX_RELAY_PASSWORD"
+    },
+    "use_doh": true,
+    "doh_timeout": 3.0
+  }
+}

--- a/flareprox.py
+++ b/flareprox.py
@@ -5,14 +5,29 @@ Redirect all traffic through Cloudflare Workers for any provided URL
 """
 
 import argparse
+import asyncio
 import getpass
 import json
 import os
 import random
+import secrets
 import requests
 import string
+import socket
+import struct
 import time
-from typing import Dict, List, Optional
+import contextlib
+from typing import Dict, List, Optional, Tuple, Union
+from urllib.parse import urlparse
+
+from websockets.exceptions import ConnectionClosed
+from websockets.legacy.client import WebSocketClientProtocol, connect as ws_connect
+import ipaddress
+
+
+# Global DNS resolution cache: hostname -> (ip, timestamp)
+_dns_cache: Dict[str, Tuple[str, float]] = {}
+_DNS_CACHE_TTL = 300  # 5 minutes
 
 
 class FlareProxError(Exception):
@@ -20,10 +35,186 @@ class FlareProxError(Exception):
     pass
 
 
+class WorkerFallbackRequired(Exception):
+    """Raised when the worker requests a relay fallback."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
+class TunnelSetupError(Exception):
+    """Raised when an upstream tunnel cannot be established."""
+    pass
+
+
+def resolve_hostname_to_ipv4(hostname: str, timeout: float = 5.0, use_cache: bool = True) -> Optional[str]:
+    """
+    Resolve a hostname to its IPv4 address using Cloudflare DNS-over-HTTPS.
+    Forces IPv4-only resolution and caches results.
+    
+    Args:
+        hostname: The hostname to resolve
+        timeout: Request timeout in seconds
+        use_cache: Whether to use cached results
+        
+    Returns:
+        IPv4 address as string, or None if resolution fails
+    """
+    # Check cache first
+    if use_cache:
+        cached = _dns_cache.get(hostname)
+        if cached:
+            ip, timestamp = cached
+            if time.time() - timestamp < _DNS_CACHE_TTL:
+                return ip
+    
+    # Resolve via Cloudflare DoH
+    try:
+        doh_url = f"https://cloudflare-dns.com/dns-query?name={hostname}&type=A"
+        headers = {"Accept": "application/dns-json"}
+        
+        response = requests.get(doh_url, headers=headers, timeout=timeout)
+        response.raise_for_status()
+        
+        data = response.json()
+        
+        # Check for successful DNS response
+        if data.get("Status") == 0 and data.get("Answer"):
+            # Find first IPv4 address in answers
+            for answer in data["Answer"]:
+                ip = answer.get("data", "")
+                # Validate IPv4 format
+                if ip and _is_valid_ipv4(ip):
+                    # Cache the result
+                    if use_cache:
+                        _dns_cache[hostname] = (ip, time.time())
+                    return ip
+        
+        return None
+        
+    except Exception:
+        # On error, return None (caller will handle)
+        return None
+
+
+def _is_valid_ipv4(ip: str) -> bool:
+    """Check if string is a valid IPv4 address."""
+    try:
+        parts = ip.split('.')
+        if len(parts) != 4:
+            return False
+        for part in parts:
+            num = int(part)
+            if num < 0 or num > 255:
+                return False
+        return True
+    except (ValueError, AttributeError):
+        return False
+
+
+def check_if_cloudflare_ip(target: str, use_doh: bool = True, doh_timeout: float = 5.0) -> Tuple[bool, str]:
+    """
+    Check if an IP address or hostname resolves to Cloudflare IP ranges.
+    
+    Args:
+        target: IP address or hostname
+        use_doh: Whether to use DNS-over-HTTPS for resolution (default: True)
+        doh_timeout: Timeout for DoH requests in seconds (default: 5.0)
+        
+    Returns:
+        Tuple of (is_cloudflare_ip, resolved_ip)
+    """
+    # Try to parse as IP first
+    try:
+        ip_obj = ipaddress.ip_address(target)
+        is_cf = _is_cloudflare_ip_address(ip_obj)
+        return (is_cf, target)
+    except ValueError:
+        pass
+    
+    # Not an IP, treat as hostname - resolve it
+    if use_doh:
+        resolved_ip = resolve_hostname_to_ipv4(target, timeout=doh_timeout)
+        if resolved_ip:
+            try:
+                ip_obj = ipaddress.ip_address(resolved_ip)
+                is_cf = _is_cloudflare_ip_address(ip_obj)
+                return (is_cf, resolved_ip)
+            except ValueError:
+                return (False, resolved_ip)
+        else:
+            # Resolution failed
+            return (False, target)
+    else:
+        # Fall back to standard DNS resolution
+        try:
+            resolved_ip = socket.gethostbyname(target)
+            ip_obj = ipaddress.ip_address(resolved_ip)
+            is_cf = _is_cloudflare_ip_address(ip_obj)
+            return (is_cf, resolved_ip)
+        except (socket.gaierror, socket.herror, ValueError):
+            return (False, target)
+
+
+def _is_cloudflare_ip_address(ip: Union[ipaddress.IPv4Address, ipaddress.IPv6Address]) -> bool:
+    """Check if an IP address object is in Cloudflare ranges."""
+    # Cloudflare IPv4 CIDR ranges
+    cf_ipv4 = (
+        "173.245.48.0/20",
+        "103.21.244.0/22",
+        "103.22.200.0/22",
+        "103.31.4.0/22",
+        "141.101.64.0/18",
+        "108.162.192.0/18",
+        "190.93.240.0/20",
+        "188.114.96.0/20",
+        "197.234.240.0/22",
+        "198.41.128.0/17",
+        "162.158.0.0/15",
+        "104.16.0.0/13",
+        "104.24.0.0/14",
+        "172.64.0.0/13",
+        "131.0.72.0/22",
+    )
+
+    # Cloudflare IPv6 CIDR ranges
+    cf_ipv6 = (
+        "2400:cb00::/32",
+        "2606:4700::/32",
+        "2803:f800::/32",
+        "2405:b500::/32",
+        "2405:8100::/32",
+        "2a06:98c0::/29",
+        "2c0f:f248::/32",
+    )
+    
+    if isinstance(ip, ipaddress.IPv4Address):
+        # Use cached networks for performance
+        if not hasattr(_is_cloudflare_ip_address, '_cf_ipv4_networks'):
+            _is_cloudflare_ip_address._cf_ipv4_networks = [
+                ipaddress.ip_network(cidr) for cidr in cf_ipv4
+            ]
+        return any(ip in network for network in _is_cloudflare_ip_address._cf_ipv4_networks)
+    else:
+        # IPv6
+        if not hasattr(_is_cloudflare_ip_address, '_cf_ipv6_networks'):
+            _is_cloudflare_ip_address._cf_ipv6_networks = [
+                ipaddress.ip_network(cidr) for cidr in cf_ipv6
+            ]
+        return any(ip in network for network in _is_cloudflare_ip_address._cf_ipv6_networks)
+
+
 class CloudflareManager:
     """Manages Cloudflare Worker deployments for FlareProx."""
 
-    def __init__(self, api_token: str, account_id: str, zone_id: Optional[str] = None):
+    def __init__(
+        self,
+        api_token: str,
+        account_id: str,
+        zone_id: Optional[str] = None,
+        worker_settings: Optional[Dict] = None
+    ):
         self.api_token = api_token
         self.account_id = account_id
         self.zone_id = zone_id
@@ -33,6 +224,7 @@ class CloudflareManager:
             "Content-Type": "application/json"
         }
         self._account_subdomain = None
+        self.worker_settings = worker_settings or {}
 
     @property
     def worker_subdomain(self) -> str:
@@ -64,147 +256,167 @@ class CloudflareManager:
         return f"flareprox-{timestamp}-{random_suffix}"
 
     def _get_worker_script(self) -> str:
-        """Return the optimized Cloudflare Worker script."""
-        return '''/**
- * FlareProx - Cloudflare Worker URL Redirection Script
- */
-addEventListener('fetch', event => {
-  event.respondWith(handleRequest(event.request))
-})
+        """Return the Cloudflare Worker script.
+        Modes:
+          - http (default): original HTTP proxy from upstream flareprox-main
+          - socks: minimal SOCKS-over-WebSocket bridge compatible with our client
+        """
+        mode = (self.worker_settings.get("mode") or "http").lower()
 
-async function handleRequest(request) {
-  try {
-    const url = new URL(request.url)
-    const targetUrl = getTargetUrl(url, request.headers)
-
-    if (!targetUrl) {
-      return createErrorResponse('No target URL specified', {
-        usage: {
-          query_param: '?url=https://example.com',
-          header: 'X-Target-URL: https://example.com',
-          path: '/https://example.com'
-        }
-      }, 400)
-    }
-
-    let targetURL
+        if mode == "http":
+            # Module-style version of the original upstream HTTP proxy
+            return """
+export default {
+  async fetch(request) {
     try {
-      targetURL = new URL(targetUrl)
-    } catch (e) {
-      return createErrorResponse('Invalid target URL', { provided: targetUrl }, 400)
-    }
-
-    // Build target URL with filtered query parameters
-    const targetParams = new URLSearchParams()
-    for (const [key, value] of url.searchParams) {
-      if (!['url', '_cb', '_t'].includes(key)) {
-        targetParams.append(key, value)
+      const url = new URL(request.url);
+      const targetUrl = getTargetUrl(url, request.headers);
+      if (!targetUrl) {
+        return createErrorResponse('No target URL specified', {
+          usage: {
+            query_param: '?url=https://example.com',
+            header: 'X-Target-URL: https://example.com',
+            path: '/https://example.com'
+          }
+        }, 400);
       }
+
+      let targetURL;
+      try { targetURL = new URL(targetUrl); }
+      catch (e) { return createErrorResponse('Invalid target URL', { provided: targetUrl }, 400); }
+
+      const targetParams = new URLSearchParams();
+      for (const [key, value] of url.searchParams) {
+        if (!['url', '_cb', '_t'].includes(key)) {
+          targetParams.append(key, value);
+        }
+      }
+      if (targetParams.toString()) {
+        targetURL.search = targetParams.toString();
+      }
+
+      const proxyRequest = createProxyRequest(request, targetURL);
+      const response = await fetch(proxyRequest);
+      return createProxyResponse(response, request.method);
+    } catch (error) {
+      return createErrorResponse('Proxy request failed', { message: error.message, timestamp: new Date().toISOString() }, 500);
     }
-    if (targetParams.toString()) {
-      targetURL.search = targetParams.toString()
-    }
-
-    // Create proxied request
-    const proxyRequest = createProxyRequest(request, targetURL)
-    const response = await fetch(proxyRequest)
-
-    // Process and return response
-    return createProxyResponse(response, request.method)
-
-  } catch (error) {
-    return createErrorResponse('Proxy request failed', {
-      message: error.message,
-      timestamp: new Date().toISOString()
-    }, 500)
   }
 }
 
 function getTargetUrl(url, headers) {
-  // Priority: query param > header > path
-  let targetUrl = url.searchParams.get('url')
-
-  if (!targetUrl) {
-    targetUrl = headers.get('X-Target-URL')
-  }
-
+  let targetUrl = url.searchParams.get('url');
+  if (!targetUrl) targetUrl = headers.get('X-Target-URL');
   if (!targetUrl && url.pathname !== '/') {
-    const pathUrl = url.pathname.slice(1)
-    if (pathUrl.startsWith('http')) {
-      targetUrl = pathUrl
-    }
+    const pathUrl = url.pathname.slice(1);
+    if (pathUrl.startsWith('http')) targetUrl = pathUrl;
   }
-
-  return targetUrl
+  return targetUrl;
 }
 
 function createProxyRequest(request, targetURL) {
-  const proxyHeaders = new Headers()
-  const allowedHeaders = [
-    'accept', 'accept-language', 'accept-encoding', 'authorization',
-    'cache-control', 'content-type', 'origin', 'referer', 'user-agent'
-  ]
-
-  // Copy allowed headers
+  const proxyHeaders = new Headers();
+  const allowedHeaders = ['accept','accept-language','accept-encoding','authorization','cache-control','content-type','origin','referer','user-agent'];
   for (const [key, value] of request.headers) {
-    if (allowedHeaders.includes(key.toLowerCase())) {
-      proxyHeaders.set(key, value)
-    }
+    if (allowedHeaders.includes(key.toLowerCase())) proxyHeaders.set(key, value);
   }
-
-  proxyHeaders.set('Host', targetURL.hostname)
-
-  // Set X-Forwarded-For header
-  const customXForwardedFor = request.headers.get('X-My-X-Forwarded-For')
-  if (customXForwardedFor) {
-    proxyHeaders.set('X-Forwarded-For', customXForwardedFor)
-  } else {
-    proxyHeaders.set('X-Forwarded-For', generateRandomIP())
-  }
-
-  return new Request(targetURL.toString(), {
-    method: request.method,
-    headers: proxyHeaders,
-    body: ['GET', 'HEAD'].includes(request.method) ? null : request.body
-  })
+  proxyHeaders.set('Host', targetURL.hostname);
+  const custom = request.headers.get('X-My-X-Forwarded-For');
+  proxyHeaders.set('X-Forwarded-For', custom || generateRandomIP());
+  return new Request(targetURL.toString(), { method: request.method, headers: proxyHeaders, body: ['GET','HEAD'].includes(request.method) ? null : request.body });
 }
 
 function createProxyResponse(response, requestMethod) {
-  const responseHeaders = new Headers()
-
-  // Copy response headers (excluding problematic ones)
+  const responseHeaders = new Headers();
   for (const [key, value] of response.headers) {
-    if (!['content-encoding', 'content-length', 'transfer-encoding'].includes(key.toLowerCase())) {
-      responseHeaders.set(key, value)
+    if (!['content-encoding','content-length','transfer-encoding'].includes(key.toLowerCase())) {
+      responseHeaders.set(key, value);
     }
   }
-
-  // Add CORS headers
-  responseHeaders.set('Access-Control-Allow-Origin', '*')
-  responseHeaders.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD')
-  responseHeaders.set('Access-Control-Allow-Headers', '*')
-
-  if (requestMethod === 'OPTIONS') {
-    return new Response(null, { status: 204, headers: responseHeaders })
-  }
-
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: responseHeaders
-  })
+  responseHeaders.set('Access-Control-Allow-Origin', '*');
+  responseHeaders.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD');
+  responseHeaders.set('Access-Control-Allow-Headers', '*');
+  if (requestMethod === 'OPTIONS') return new Response(null, { status: 204, headers: responseHeaders });
+  return new Response(response.body, { status: response.status, statusText: response.statusText, headers: responseHeaders });
 }
 
 function createErrorResponse(error, details, status) {
-  return new Response(JSON.stringify({ error, ...details }), {
-    status,
-    headers: { 'Content-Type': 'application/json' }
-  })
+  return new Response(JSON.stringify({ error, ...details }), { status, headers: { 'Content-Type': 'application/json' } });
 }
 
 function generateRandomIP() {
-  return [1, 2, 3, 4].map(() => Math.floor(Math.random() * 255) + 1).join('.')
-}'''
+  return [1,2,3,4].map(() => Math.floor(Math.random()*255)+1).join('.');
+}
+"""
+
+        # SOCKS-over-WebSocket minimal bridge (keeps 'ready' control for client compatibility)
+        auth_token = json.dumps(self.worker_settings.get("auth_token", ""))
+        socks_password = json.dumps(self.worker_settings.get("socks_password", ""))
+        return ("""
+import { connect } from 'cloudflare:sockets';
+
+const AUTH_TOKEN = AUTH_TOKEN_PLACEHOLDER;
+const SOCKS_PASSWORD = SOCKS_PASSWORD_PLACEHOLDER;
+const textEncoder = new TextEncoder();
+
+export default {
+  async fetch(request) {
+    if (AUTH_TOKEN && request.headers.get('Authorization') !== AUTH_TOKEN) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+    if (request.headers.get('Upgrade') !== 'websocket') {
+      return new Response('Expected Upgrade: websocket', { status: 426 });
+    }
+
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    server.accept();
+    server.binaryType = 'arraybuffer';
+
+    server.addEventListener('message', async ({ data }) => {
+      try {
+        if (typeof data !== 'string') { server.close(1003, 'Invalid request'); return; }
+        const payload = JSON.parse(data);
+        const hostname = payload.hostname;
+        const port = Number(payload.port);
+        const password = payload.password ?? payload.psw ?? '';
+        if (!hostname || !Number.isInteger(port) || port < 1 || port > 65535) { server.close(1008, 'Invalid target'); return; }
+        if (SOCKS_PASSWORD && password !== SOCKS_PASSWORD) { server.close(1008, 'Invalid credentials'); return; }
+
+        let socket;
+        try { socket = connect({ hostname, port }); }
+        catch (e) { server.close(1011, 'Upstream connect failed'); return; }
+
+        // Minimal control for client handshake
+        try { server.send(JSON.stringify({ type: 'ready' })); } catch (_) {}
+
+        const inbound = new ReadableStream({
+          start(controller) {
+            server.addEventListener('message', event => {
+              const p = event.data;
+              if (typeof p === 'string') controller.enqueue(textEncoder.encode(p));
+              else if (p instanceof ArrayBuffer) controller.enqueue(new Uint8Array(p));
+            });
+            server.addEventListener('error', ev => controller.error(ev));
+            server.addEventListener('close', () => controller.close());
+          },
+          cancel() { try { socket && socket.close && socket.close(); } catch (_) {} }
+        });
+
+        inbound.pipeTo(socket.writable).catch(() => server.close(1011, 'Client error'));
+        socket.readable.pipeTo(new WritableStream({
+          write(chunk) { server.send(chunk instanceof ArrayBuffer ? chunk : new Uint8Array(chunk)); },
+          close() { server.close(); },
+          abort() { server.close(1011, 'Upstream aborted'); }
+        })).catch(() => server.close(1011, 'Upstream error'));
+      } catch (e) { server.close(1003, 'Invalid request'); }
+    }, { once: true });
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+}
+"""
+        ).replace("AUTH_TOKEN_PLACEHOLDER", auth_token).replace("SOCKS_PASSWORD_PLACEHOLDER", socks_password)
 
     def create_deployment(self, name: Optional[str] = None) -> Dict:
         """Deploy a new Cloudflare Worker."""
@@ -214,12 +426,21 @@ function generateRandomIP() {
         script_content = self._get_worker_script()
         url = f"{self.base_url}/accounts/{self.account_id}/workers/scripts/{name}"
 
+        compatibility_flags = self.worker_settings.get("compatibility_flags", ["nodejs_compat"])
+        if isinstance(compatibility_flags, str):
+            compatibility_flags = [compatibility_flags]
+        elif not isinstance(compatibility_flags, list):
+            compatibility_flags = ["nodejs_compat"]
+
+        metadata = {
+            "main_module": "worker.js",
+            "compatibility_date": self.worker_settings.get("compatibility_date", "2023-09-04"),
+            "compatibility_flags": compatibility_flags
+        }
+
         files = {
-            'metadata': (None, json.dumps({
-                "body_part": "script",
-                "main_module": "worker.js"
-            })),
-            'script': ('worker.js', script_content, 'application/javascript')
+            'metadata': (None, json.dumps(metadata), 'application/json'),
+            'worker.js': ('worker.js', script_content, 'application/javascript+module')
         }
 
         headers = {"Authorization": f"Bearer {self.api_token}"}
@@ -227,6 +448,20 @@ function generateRandomIP() {
         try:
             response = requests.put(url, headers=headers, files=files, timeout=60)
             response.raise_for_status()
+        except requests.HTTPError as e:
+            detail = ""
+            if e.response is not None:
+                try:
+                    payload = e.response.json()
+                    errors = payload.get("errors") if isinstance(payload, dict) else None
+                    if errors:
+                        detail = json.dumps(errors)
+                    elif payload:
+                        detail = json.dumps(payload)
+                except (ValueError, AttributeError):
+                    detail = e.response.text
+            message = detail or str(e)
+            raise FlareProxError(f"Failed to create worker: {message}")
         except requests.RequestException as e:
             raise FlareProxError(f"Failed to create worker: {e}")
 
@@ -245,7 +480,9 @@ function generateRandomIP() {
             "name": name,
             "url": worker_url,
             "created_at": time.strftime('%Y-%m-%d %H:%M:%S'),
-            "id": worker_data.get("result", {}).get("id", name)
+            "id": worker_data.get("result", {}).get("id", name),
+            "auth_token": self.worker_settings.get("auth_token", ""),
+            "socks_password": self.worker_settings.get("socks_password", "")
         }
 
     def list_deployments(self) -> List[Dict]:
@@ -306,21 +543,621 @@ function generateRandomIP() {
                 print(f"Error deleting worker: {worker['name']}")
 
 
+class LocalSocksServer:
+    def __init__(self, endpoint: Dict, worker_defaults: Dict, client_defaults: Dict, bind_host: str):
+        self.endpoint = dict(endpoint)
+        self.bind_host = bind_host
+        self.auth_token = self.endpoint.get("auth_token") or worker_defaults.get("auth_token", "")
+        self.socks_password = self.endpoint.get("socks_password") or worker_defaults.get("socks_password", "")
+        self.websocket_url = self._build_websocket_url(self.endpoint.get("url", ""))
+        self.name = self.endpoint.get("name", "unknown")
+        self._server: Optional[asyncio.AbstractServer] = None
+        self.port: Optional[int] = None
+        self.cf_override_ip = (client_defaults.get("cf_override_ip") or "").strip()
+        self.cf_hostnames = [h.lower() for h in client_defaults.get("cf_hostnames", []) if isinstance(h, str)]
+        relay_defaults = client_defaults.get("relay") if isinstance(client_defaults.get("relay"), dict) else {}
+        self.relay_config = dict(relay_defaults)
+        self.relay_url = (self.relay_config.get("url") or "").strip()
+        self.relay_auth_token = (self.relay_config.get("auth_token") or "").strip()
+        relay_password = (self.relay_config.get("socks_password") or "").strip()
+        self.relay_password = relay_password or self.socks_password
+        self.relay_enabled = bool(self.relay_config.get("enabled")) and bool(self.relay_url)
+        self.handshake_timeout = float(self.relay_config.get("handshake_timeout", client_defaults.get("handshake_timeout", 5.0)))
+        # Increase default buffer to 256KB to capture full TLS handshakes
+        replay_limit = self.relay_config.get("retry_buffer_bytes", 262144)
+        try:
+            replay_limit = int(replay_limit)
+        except (TypeError, ValueError):
+            replay_limit = 262144
+        self.replay_buffer_bytes = max(0, replay_limit)
+        # DoH settings
+        self.use_doh = bool(client_defaults.get("use_doh", True))
+        self.doh_timeout = float(client_defaults.get("doh_timeout", 5.0))
+
+    class _HandshakeState:
+        def __init__(self, limit: int) -> None:
+            self.limit = max(0, int(limit))
+            self._segments: List[bytes] = []
+            self._captured = 0
+            self._replay_consumed = False
+            self.confirmed = False
+
+        def record(self, chunk: bytes) -> None:
+            if self.confirmed or self._replay_consumed or self.limit == 0 or not chunk:
+                return
+            available = self.limit - self._captured
+            if available <= 0:
+                return
+            piece = bytes(chunk[:available])
+            if piece:
+                self._segments.append(piece)
+                self._captured += len(piece)
+
+        def mark_established(self) -> None:
+            if not self.confirmed:
+                self.confirmed = True
+                self._segments.clear()
+
+        @property
+        def has_replay(self) -> bool:
+            return not self.confirmed and not self._replay_consumed and bool(self._segments)
+
+        def consume(self) -> List[bytes]:
+            if not self.has_replay:
+                return []
+            self._replay_consumed = True
+            segments = list(self._segments)
+            self._segments.clear()
+            return segments
+
+    @staticmethod
+    def _parse_control_frame(message: str) -> Optional[Dict]:
+        if not message or len(message) > 65536:
+            return None
+        try:
+            data = json.loads(message)
+        except (TypeError, ValueError):
+            return None
+
+        if isinstance(data, dict) and isinstance(data.get("type"), str):
+            return data
+        return None
+
+    @staticmethod
+    def _build_websocket_url(url: str) -> str:
+        parsed = urlparse(url)
+        scheme = 'wss' if parsed.scheme == 'https' else 'ws'
+        path = parsed.path or ''
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+        if not parsed.netloc:
+            return url
+        return f"{scheme}://{parsed.netloc}{path}"
+
+    async def start(self, port_hint: Optional[int] = None) -> None:
+        if not self.websocket_url:
+            raise FlareProxError(f"Endpoint {self.name} does not have a valid URL.")
+
+        listen_port = port_hint if port_hint not in (None, 0) else 0
+
+        try:
+            self._server = await asyncio.start_server(self._handle_client, self.bind_host, listen_port)
+        except OSError:
+            if listen_port != 0:
+                self._server = await asyncio.start_server(self._handle_client, self.bind_host, 0)
+            else:
+                raise
+
+        sock = self._server.sockets[0].getsockname()
+        self.port = sock[1]
+
+    async def close(self) -> None:
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    async def _handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        websocket: Optional[WebSocketClientProtocol] = None
+        peer = writer.get_extra_info('peername', 'unknown')
+
+        try:
+            result = await self._negotiate(reader, writer)
+            if not result:
+                print(f"{self.name}: negotiation failed from {peer}")
+                return
+
+            hostname, port, request_data = result
+            print(f"{self.name}: SOCKS request from {peer} to {hostname}:{port}")
+            
+            # Check if target matches manual CF hostname list for override
+            connect_hostname = hostname
+            if self.cf_override_ip and self._matches_cf_host(hostname.lower()):
+                connect_hostname = self.cf_override_ip
+
+            try:
+                websocket, upstream_source = await self._connect_upstream(
+                    connect_hostname, hostname, port
+                )
+            except TunnelSetupError as e:
+                print(f"{self.name}: upstream failed for {hostname}:{port} - {e}")
+                await self._send_failure(writer)
+                return
+
+            await self._send_success(writer, request_data)
+
+            websocket = await self._bridge_streams(
+                reader,
+                writer,
+                websocket,
+                upstream_source,
+                hostname,
+                port
+            )
+
+        except FlareProxError as e:
+            print(f"{self.name}: FlareProxError from {peer} - {e}")
+        except asyncio.IncompleteReadError as e:
+            print(f"{self.name}: IncompleteRead from {peer} - {e}")
+        except Exception as e:
+            print(f"{self.name}: unexpected error from {peer} - {type(e).__name__}: {e}")
+        finally:
+            with contextlib.suppress(Exception):
+                if websocket is not None:
+                    await websocket.close()
+            with contextlib.suppress(Exception):
+                writer.close()
+                await writer.wait_closed()
+
+    async def _negotiate(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> Optional[Tuple[str, int, bytes]]:
+        try:
+            header = await reader.readexactly(2)
+        except asyncio.IncompleteReadError:
+            return None
+
+        version, method_count = header
+        if version != 5:
+            return None
+
+        try:
+            await reader.readexactly(method_count)
+        except asyncio.IncompleteReadError:
+            return None
+
+        writer.write(b"\x05\x00")
+        await writer.drain()
+
+        try:
+            request = await reader.readexactly(4)
+        except asyncio.IncompleteReadError:
+            return None
+
+        version, command, _, address_type = request
+        if version != 5 or command != 1:
+            await self._send_failure(writer, 0x07)
+            return None
+
+        # Build the full request data to echo back in success response
+        request_data = bytearray(request)
+
+        try:
+            if address_type == 1:
+                raw_address = await reader.readexactly(4)
+                hostname = socket.inet_ntoa(raw_address)
+                request_data.extend(raw_address)
+            elif address_type == 3:
+                length = await reader.readexactly(1)
+                raw_address = await reader.readexactly(length[0])
+                hostname = raw_address.decode("utf-8")
+                request_data.extend(length)
+                request_data.extend(raw_address)
+            elif address_type == 4:
+                raw_address = await reader.readexactly(16)
+                hostname = socket.inet_ntop(socket.AF_INET6, raw_address)
+                request_data.extend(raw_address)
+            else:
+                await self._send_failure(writer, 0x08)
+                return None
+
+            raw_port = await reader.readexactly(2)
+            port = struct.unpack(">H", raw_port)[0]
+            request_data.extend(raw_port)
+        except asyncio.IncompleteReadError:
+            return None
+
+        if port <= 0 or port > 65535:
+            await self._send_failure(writer, 0x09)
+            return None
+
+        return hostname, port, bytes(request_data)
+
+    async def _bridge_streams(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        websocket: WebSocketClientProtocol,
+        upstream_source: str,
+        original_hostname: str,
+        port: int
+    ) -> Optional[WebSocketClientProtocol]:
+        print(f"{self.name}: bridging {original_hostname}:{port} via {upstream_source}")
+        active_ws = websocket
+        active_source = upstream_source
+        handshake_state = self._HandshakeState(self.replay_buffer_bytes)
+        fallback_used = active_source != "worker"
+
+        client_task = asyncio.create_task(reader.read(65536), name=f"client-{original_hostname}")
+        upstream_task = asyncio.create_task(active_ws.recv(), name=f"upstream-{original_hostname}")
+
+        async def switch_to_relay(reason: str) -> None:
+            nonlocal active_ws, active_source, fallback_used, client_task, upstream_task
+
+            if fallback_used:
+                raise TunnelSetupError(reason)
+            if not self.relay_enabled:
+                raise TunnelSetupError(reason)
+
+            # Get any buffered data (might be empty if worker closed before client sent anything)
+            replay_segments = handshake_state.consume()
+
+            old_client_task = client_task
+            old_upstream_task = upstream_task
+
+            if old_client_task and not old_client_task.done():
+                old_client_task.cancel()
+                with contextlib.suppress(Exception):
+                    await old_client_task
+
+            if old_upstream_task and not old_upstream_task.done():
+                old_upstream_task.cancel()
+                with contextlib.suppress(Exception):
+                    await old_upstream_task
+
+            with contextlib.suppress(Exception):
+                await active_ws.close()
+
+            active_ws = await self._connect_relay(original_hostname, port)
+            
+            # Replay any buffered data (if any)
+            if replay_segments:
+                for segment in replay_segments:
+                    if segment:
+                        await active_ws.send(segment)
+                print(f"{self.name}: retry via relay ({reason}) for {original_hostname}:{port} with {sum(len(s) for s in replay_segments)} bytes buffered")
+            else:
+                print(f"{self.name}: retry via relay ({reason}) for {original_hostname}:{port} - fresh connection, no buffered data")
+
+            active_source = "relay"
+            fallback_used = True
+            client_task = asyncio.create_task(reader.read(65536), name=f"client-{original_hostname}")
+            upstream_task = asyncio.create_task(active_ws.recv(), name=f"upstream-{original_hostname}")
+
+        try:
+            while True:
+                done, _ = await asyncio.wait(
+                    [client_task, upstream_task],
+                    return_when=asyncio.FIRST_COMPLETED
+                )
+
+                client_done = client_task in done
+                upstream_done = upstream_task in done
+
+                # Always handle upstream-side events first. This ensures that
+                # early worker closes trigger relay failover even when the
+                # client hasn't sent data yet (browser behavior).
+                if upstream_done:
+                    try:
+                        message = upstream_task.result()
+                    except (ConnectionClosed, OSError, asyncio.IncompleteReadError, Exception) as exc:
+                        # Catch-all: any connection failure before handshake = retry via relay
+                        if (
+                            active_source == "worker"
+                            and not handshake_state.confirmed
+                            and self.relay_enabled
+                        ):
+                            # If the client already had data ready in this iteration,
+                            # capture it into the handshake buffer so it can be replayed
+                            # after switching to the relay.
+                            if client_done:
+                                try:
+                                    if client_task.exception() is None:
+                                        _buf = client_task.result()
+                                        if _buf:
+                                            handshake_state.record(_buf)
+                                except Exception:
+                                    pass
+                            try:
+                                reason = f"worker connection lost: {type(exc).__name__}"
+                                await switch_to_relay(reason)
+                                continue
+                            except TunnelSetupError as fallback_exc:
+                                raise fallback_exc from exc
+                        if handshake_state.confirmed:
+                            break
+                        raise TunnelSetupError(f"Upstream connection failed: {exc}") from exc
+
+                    # Normal upstream message path
+                    if isinstance(message, str):
+                        payload = None
+                        if not handshake_state.confirmed:
+                            control = self._parse_control_frame(message)
+                            if control:
+                                ctrl_type = control.get("type")
+                                reason = control.get("message") or control.get("code") or "Upstream reported error"
+                                if ctrl_type == "error":
+                                    if active_source == "worker" and not fallback_used:
+                                        try:
+                                            await switch_to_relay(reason)
+                                            continue
+                                        except TunnelSetupError as fallback_exc:
+                                            raise fallback_exc
+                                    raise TunnelSetupError(reason)
+                                if ctrl_type == "ready":
+                                    upstream_task = asyncio.create_task(active_ws.recv(), name=f"upstream-{original_hostname}")
+                                    # Continue to also process client-side readiness in the same iteration
+                                    # (do not 'continue' here).
+                                else:
+                                    # Ignore unknown control frames before handshake completion
+                                    upstream_task = asyncio.create_task(active_ws.recv(), name=f"upstream-{original_hostname}")
+                                # Fall through to client processing if any
+                                
+                        else:
+                            payload = message.encode("utf-8")
+                    else:
+                        payload = message
+
+                    if payload:
+                        was_unconfirmed = not handshake_state.confirmed
+                        handshake_state.mark_established()
+                        if was_unconfirmed:
+                            print(f"{self.name}: handshake established for {original_hostname}:{port}")
+                        try:
+                            writer.write(payload)
+                            await writer.drain()
+                        except Exception as exc:
+                            raise TunnelSetupError("Failed to forward upstream data to client") from exc
+                    # Re-arm upstream task if we didn't switch to relay
+                    if active_ws is not None:
+                        upstream_task = asyncio.create_task(active_ws.recv(), name=f"upstream-{original_hostname}")
+
+                if client_done:
+                    # Check for task exception
+                    if client_task.exception() is not None and not isinstance(client_task.exception(), (asyncio.CancelledError,)):
+                        exc = client_task.exception()
+                        print(f"{self.name}: client task error for {original_hostname}:{port} - {type(exc).__name__}")
+                        raise TunnelSetupError(f"Client read error: {exc}") from exc
+                    data = client_task.result()
+                    if not data:
+                        break
+                    handshake_state.record(data)
+                    try:
+                        await active_ws.send(data)
+                    except (ConnectionClosed, OSError, Exception) as exc:
+                        # Catch-all: any send failure before handshake = retry via relay
+                        if (
+                            active_source == "worker"
+                            and not handshake_state.confirmed
+                            and self.relay_enabled
+                        ):
+                            try:
+                                reason = f"worker send failed: {type(exc).__name__}"
+                                await switch_to_relay(reason)
+                                continue
+                            except TunnelSetupError as fallback_exc:
+                                raise fallback_exc from exc
+                        if handshake_state.confirmed:
+                            break
+                        raise TunnelSetupError(f"Failed to send to upstream: {exc}") from exc
+                    client_task = asyncio.create_task(reader.read(65536), name=f"client-{original_hostname}")
+        finally:
+            # Properly clean up tasks to avoid "exception never retrieved" warnings
+            for task in (client_task, upstream_task):
+                if not task.done():
+                    task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                except Exception as e:
+                    # Log but suppress exceptions from canceled tasks
+                    print(f"{self.name}: task cleanup exception for {original_hostname}:{port} - {type(e).__name__}")
+
+        return active_ws
+
+    async def _send_failure(self, writer: asyncio.StreamWriter, code: int = 0x01) -> None:
+        writer.write(b"\x05" + bytes([code]) + b"\x00\x01" + b"\x00\x00\x00\x00" + b"\x00\x00")
+        await writer.drain()
+
+    async def _send_success(self, writer: asyncio.StreamWriter, request_data: bytes) -> None:
+        # Send a minimal RFC 1928-compliant success reply.
+        # For CONNECT, BND.ADDR/BND.PORT are the server-bound address; it's
+        # acceptable to return IPv4 0.0.0.0:0, which is widely used and
+        # compatible with Firefox/Chrome/curl.
+        writer.write(b"\x05\x00\x00\x01" + b"\x00\x00\x00\x00" + b"\x00\x00")
+        await writer.drain()
+
+    async def _connect_upstream(
+        self, 
+        connect_hostname: str, 
+        original_hostname: str, 
+        port: int
+    ) -> Tuple[WebSocketClientProtocol, str]:
+        # Pre-detect Cloudflare destinations and configured CF hostnames.
+        # If detected, prefer immediate relay to avoid CF->CF worker egress failures.
+        try:
+            # Match configured hostname patterns first
+            if self._matches_cf_host(original_hostname.lower()):
+                if self.relay_enabled:
+                    print(f"{self.name}: pre-fallback to relay for {original_hostname}:{port} (hostname matches cf_hostnames)")
+                    websocket = await self._connect_relay(original_hostname, port)
+                    return websocket, "relay"
+            # Resolve with DoH (if enabled) and check CF ranges
+            is_cf, resolved_ip = check_if_cloudflare_ip(
+                original_hostname,
+                use_doh=self.use_doh,
+                doh_timeout=self.doh_timeout,
+            )
+            if is_cf and self.relay_enabled:
+                print(f"{self.name}: pre-fallback to relay for {original_hostname}:{port} (Target served by Cloudflare IP range)")
+                websocket = await self._connect_relay(original_hostname, port)
+                return websocket, "relay"
+        except Exception:
+            # Ignore detection errors and continue with normal flow
+            pass
+
+        # Try worker first (default path)
+        try:
+            websocket = await self._connect_worker(connect_hostname, port)
+            return websocket, "worker"
+        except WorkerFallbackRequired as exc:
+            # Worker explicitly requested relay (e.g., CF IP detected)
+            if not self.relay_enabled:
+                raise TunnelSetupError(exc.reason)
+            print(f"{self.name}: fallback to relay for {original_hostname}:{port} ({exc.reason})")
+            websocket = await self._connect_relay(original_hostname, port)
+            return websocket, "relay"
+
+    async def _connect_worker(self, hostname: str, port: int) -> WebSocketClientProtocol:
+        extra_headers = {}
+        if self.auth_token:
+            extra_headers["Authorization"] = self.auth_token
+
+        try:
+            websocket = await ws_connect(self.websocket_url, extra_headers=extra_headers, max_size=None)
+        except Exception as exc:
+            raise TunnelSetupError(f"Failed to open worker tunnel: {exc}") from exc
+
+        try:
+            await websocket.send(json.dumps({
+                "hostname": hostname,
+                "port": port,
+                "password": self.socks_password
+            }))
+        except Exception as exc:
+            with contextlib.suppress(Exception):
+                await websocket.close()
+            raise TunnelSetupError("Failed to transmit worker handshake") from exc
+
+        control = await self._await_control_message(websocket)
+        if control.get("type") == "ready":
+            return websocket
+
+        message = control.get("message") or control.get("code") or "Worker rejected connection"
+        with contextlib.suppress(Exception):
+            await websocket.close()
+
+        if control.get("code") == "cloudflare-blocked":
+            raise WorkerFallbackRequired(message)
+
+        raise TunnelSetupError(message)
+
+    async def _connect_relay(self, hostname: str, port: int) -> WebSocketClientProtocol:
+        if not self.relay_enabled or not self.relay_url:
+            raise TunnelSetupError("Relay not configured")
+
+        extra_headers = {}
+        if self.relay_auth_token:
+            extra_headers["Authorization"] = self.relay_auth_token
+
+        try:
+            websocket = await ws_connect(self.relay_url, extra_headers=extra_headers, max_size=None)
+        except Exception as exc:
+            raise TunnelSetupError(f"Failed to open relay tunnel: {exc}") from exc
+
+        try:
+            await websocket.send(json.dumps({
+                "hostname": hostname,
+                "port": port,
+                "password": self.relay_password
+            }))
+        except Exception as exc:
+            with contextlib.suppress(Exception):
+                await websocket.close()
+            raise TunnelSetupError("Failed to transmit relay handshake") from exc
+
+        control = await self._await_control_message(websocket)
+        if control.get("type") == "ready":
+            return websocket
+
+        message = control.get("message") or control.get("code") or "Relay rejected connection"
+        with contextlib.suppress(Exception):
+            await websocket.close()
+        raise TunnelSetupError(message)
+
+    async def _await_control_message(self, websocket: WebSocketClientProtocol) -> Dict:
+        try:
+            raw = await asyncio.wait_for(websocket.recv(), timeout=self.handshake_timeout)
+        except asyncio.TimeoutError as exc:
+            raise TunnelSetupError("Timed out waiting for upstream acknowledgement") from exc
+        except Exception as exc:
+            raise TunnelSetupError("Upstream channel closed during handshake") from exc
+
+        if isinstance(raw, (bytes, bytearray, memoryview)):
+            raise TunnelSetupError("Unexpected binary response from upstream")
+
+        try:
+            data = json.loads(raw)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise TunnelSetupError("Invalid control response from upstream") from exc
+
+        if not isinstance(data, dict):
+            raise TunnelSetupError("Malformed control response from upstream")
+
+        return data
+
+    def _matches_cf_host(self, hostname: str) -> bool:
+        """Check if hostname matches configured Cloudflare hostname patterns."""
+        if not self.cf_hostnames:
+            return False
+
+        for entry in self.cf_hostnames:
+            if hostname == entry:
+                return True
+            if entry.startswith("*.") and hostname.endswith(entry[1:]):
+                return True
+        return False
+
+
+class SocksServerGroup:
+    def __init__(self, servers: List[LocalSocksServer]):
+        self.servers = servers
+
+    def summary(self) -> List[Tuple[str, str, int]]:
+        report = []
+        for server in self.servers:
+            if server.port is not None:
+                report.append((server.name, server.bind_host, server.port))
+        return report
+
+    async def close(self) -> None:
+        await asyncio.gather(*(server.close() for server in self.servers), return_exceptions=True)
+
+
 class FlareProx:
     """Main FlareProx manager class."""
 
     def __init__(self, config_file: Optional[str] = None):
+        self._config_path = None
+        self._config_dirty = False
         self.config = self._load_config(config_file)
+        self.worker_settings = self._prepare_worker_settings(self.config.get("worker", {}))
+        self.client_settings = self._prepare_client_settings(self.config.get("client", {}))
+        self.config["worker"] = self.worker_settings
+        self.config["client"] = self.client_settings
         self.cloudflare = self._setup_cloudflare()
         self.endpoints_file = "flareprox_endpoints.json"
         self._ensure_config_file_exists()
 
+        if self._config_dirty:
+            self._persist_config()
+
     def _load_config(self, config_file: Optional[str] = None) -> Dict:
         """Load configuration from file."""
-        config = {"cloudflare": {}}
+        config = {"cloudflare": {}, "worker": {}, "client": {}}
 
         # Try specified config file
         if config_file and os.path.exists(config_file):
+            self._config_path = config_file
             config = self._load_config_file(config_file, config)
 
         # Try default config files
@@ -332,8 +1169,13 @@ class FlareProx:
 
         for default_config in default_configs:
             if os.path.exists(default_config):
+                if not self._config_path:
+                    self._config_path = default_config
                 config = self._load_config_file(default_config, config)
                 break
+
+        if not self._config_path:
+            self._config_path = config_file or "flareprox.json"
 
         return config
 
@@ -343,8 +1185,14 @@ class FlareProx:
             with open(config_path, 'r') as f:
                 file_config = json.load(f)
 
-            if "cloudflare" in file_config and not config["cloudflare"]:
+            if "cloudflare" in file_config:
                 config["cloudflare"].update(file_config["cloudflare"])
+
+            if "worker" in file_config and isinstance(file_config["worker"], dict):
+                config["worker"].update(file_config["worker"])
+
+            if "client" in file_config and isinstance(file_config["client"], dict):
+                config["client"].update(file_config["client"])
         except (json.JSONDecodeError, IOError) as e:
             print(f"Warning: Could not load config file {config_path}: {e}")
 
@@ -360,7 +1208,8 @@ class FlareProx:
             return CloudflareManager(
                 api_token=api_token,
                 account_id=account_id,
-                zone_id=cf_config.get("zone_id")
+                zone_id=cf_config.get("zone_id"),
+                worker_settings=self.worker_settings
             )
         return None
 
@@ -375,6 +1224,118 @@ class FlareProx:
             # Don't create a default config automatically
             # Let the user run 'python3 flareprox.py config' to set up
             pass
+
+    def _persist_config(self) -> None:
+        if not self._config_path:
+            return
+
+        try:
+            with open(self._config_path, 'w') as f:
+                json.dump(self.config, f, indent=2)
+        except IOError as e:
+            print(f"Warning: Could not update config file {self._config_path}: {e}")
+        finally:
+            self._config_dirty = False
+
+    def _generate_secret(self, size: int = 24) -> str:
+        return secrets.token_urlsafe(size)
+
+    def _prepare_worker_settings(self, worker_config: Dict) -> Dict:
+        settings = dict(worker_config or {})
+        updated = False
+
+        if "mode" not in settings:
+            settings["mode"] = "http"  # default behavior matches original project
+            updated = True
+
+        if not settings.get("socks_password"):
+            settings["socks_password"] = self._generate_secret()
+            print("Generated worker SOCKS password for this session. Update your config to persist it.")
+            updated = True
+
+        if "auth_token" not in settings:
+            settings["auth_token"] = ""
+            updated = True
+
+        if not settings.get("compatibility_date"):
+            settings["compatibility_date"] = "2023-09-04"
+            updated = True
+
+        flags = settings.get("compatibility_flags")
+        if not isinstance(flags, list) or not flags:
+            settings["compatibility_flags"] = ["nodejs_compat"]
+            updated = True
+
+        if updated:
+            self._config_dirty = True
+
+        return settings
+
+    def _prepare_client_settings(self, client_config: Dict) -> Dict:
+        settings = dict(client_config or {})
+        updated = False
+
+        if "bind_host" not in settings:
+            settings["bind_host"] = "127.0.0.1"
+            updated = True
+
+        if "base_port" not in settings:
+            settings["base_port"] = 1080
+            updated = True
+
+        if "profiles" not in settings:
+            settings["profiles"] = []  # reserved for future multi-client support
+            updated = True
+
+        if "auto_random_ports" not in settings:
+            settings["auto_random_ports"] = True
+            updated = True
+
+        if "cf_override_ip" not in settings:
+            settings["cf_override_ip"] = ""
+            updated = True
+
+        if "cf_hostnames" not in settings:
+            settings["cf_hostnames"] = []
+            updated = True
+
+        if "handshake_timeout" not in settings:
+            settings["handshake_timeout"] = 5.0
+            updated = True
+
+        if "use_doh" not in settings:
+            settings["use_doh"] = True  # Enable DoH by default
+            updated = True
+
+        if "doh_timeout" not in settings:
+            settings["doh_timeout"] = 5.0
+            updated = True
+
+        relay_cfg = settings.get("relay")
+        if not isinstance(relay_cfg, dict):
+            settings["relay"] = {
+                "enabled": False,
+                "url": "",
+                "auth_token": "",
+                "socks_password": ""
+            }
+            updated = True
+        else:
+            defaults = {
+                "enabled": False,
+                "url": "",
+                "auth_token": "",
+                "socks_password": ""
+            }
+            for key, value in defaults.items():
+                if key not in relay_cfg:
+                    relay_cfg[key] = value
+                    updated = True
+
+        if updated:
+            self._config_dirty = True
+
+        return settings
 
     @property
     def is_configured(self) -> bool:
@@ -399,15 +1360,119 @@ class FlareProx:
                 pass
         return []
 
+    def _merge_and_save_endpoints(self, new_entries: List[Dict]) -> None:
+        if not new_entries:
+            return
+
+        existing = {entry.get("name"): entry for entry in self._load_endpoints() if entry.get("name")}
+
+        for entry in new_entries:
+            name = entry.get("name")
+            if not name:
+                continue
+            if name in existing:
+                existing[name].update(entry)
+            else:
+                existing[name] = entry
+
+        self._save_endpoints(list(existing.values()))
+
+    def _prepare_endpoint_for_client(self, endpoint: Dict) -> Dict:
+        prepared = dict(endpoint)
+        prepared.setdefault("auth_token", self.worker_settings.get("auth_token", ""))
+        prepared.setdefault("socks_password", self.worker_settings.get("socks_password", ""))
+        return prepared
+
+    def _select_endpoints_for_client(self, limit: Optional[int] = None) -> List[Dict]:
+        endpoints = self._load_endpoints()
+        if limit and limit > 0:
+            endpoints = endpoints[:limit]
+        return [self._prepare_endpoint_for_client(endpoint) for endpoint in endpoints]
+
+    def run_socks_servers(
+        self,
+        endpoints: List[Dict],
+        bind_host: Optional[str] = None,
+        base_port: Optional[int] = None,
+        auto_random: Optional[bool] = None
+    ) -> None:
+        if not endpoints:
+            print("No endpoints available to start SOCKS servers.")
+            return
+
+        host = bind_host or self.client_settings.get("bind_host")
+        random_ports = self.client_settings.get("auto_random_ports", True) if auto_random is None else auto_random
+        start_port = base_port if base_port is not None else self.client_settings.get("base_port")
+
+        prepared = [self._prepare_endpoint_for_client(endpoint) for endpoint in endpoints]
+
+        try:
+            asyncio.run(self._run_socks_servers(prepared, host, start_port, random_ports))
+        except KeyboardInterrupt:
+            print("\nStopped local SOCKS proxies.")
+
+    async def _run_socks_servers(
+        self,
+        endpoints: List[Dict],
+        bind_host: str,
+        base_port: Optional[int],
+        auto_random: bool
+    ) -> None:
+        servers: List[LocalSocksServer] = []
+        group: Optional[SocksServerGroup] = None
+        try:
+            for index, endpoint in enumerate(endpoints):
+                port_hint: Optional[int]
+                if auto_random:
+                    port_hint = None
+                else:
+                    start = base_port if base_port is not None else 0
+                    port_hint = start + index
+
+                server = LocalSocksServer(endpoint, self.worker_settings, self.client_settings, bind_host)
+                await server.start(port_hint)
+                servers.append(server)
+
+            group = SocksServerGroup(servers)
+            self._print_socks_summary(group)
+
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                pass
+        finally:
+            if group:
+                await group.close()
+            elif servers:
+                await SocksServerGroup(servers).close()
+
+    def _print_socks_summary(self, group: SocksServerGroup) -> None:
+        print("\nLocal SOCKS proxies:")
+        for name, host, port in group.summary():
+            print(f"  {name}: socks5://{host}:{port}")
+        print("Press Ctrl+C to stop.\n")
+
     def sync_endpoints(self) -> List[Dict]:
         """Sync local endpoints with remote deployments."""
         if not self.cloudflare:
             return []
 
         try:
-            endpoints = self.cloudflare.list_deployments()
-            self._save_endpoints(endpoints)
-            return endpoints
+            remote_endpoints = self.cloudflare.list_deployments()
+            local_map = {endpoint.get("name"): endpoint for endpoint in self._load_endpoints() if endpoint.get("name")}
+
+            merged = []
+            for endpoint in remote_endpoints:
+                name = endpoint.get("name")
+                if name and name in local_map:
+                    extra = local_map[name]
+                    combined = {**extra, **endpoint}
+                    merged.append(combined)
+                else:
+                    merged.append(endpoint)
+
+            self._save_endpoints(merged)
+            return merged
         except FlareProxError as e:
             print(f"Warning: Could not sync endpoints: {e}")
             return self._load_endpoints()
@@ -431,6 +1496,7 @@ class FlareProx:
                 results["failed"] += 1
 
         # Update local cache
+        self._merge_and_save_endpoints(results["created"])
         self.sync_endpoints()
 
         total_created = len(results["created"])
@@ -633,13 +1699,15 @@ def create_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="FlareProx - Simple URL Redirection via Cloudflare Workers")
 
     parser.add_argument("command", nargs='?',
-                       choices=["create", "list", "test", "cleanup", "help", "config"],
+                       choices=["create", "list", "test", "cleanup", "help", "config", "socks"],
                        help="Command to execute")
 
     parser.add_argument("--url", help="Target URL")
     parser.add_argument("--method", default="GET", help="HTTP method (default: GET)")
-    parser.add_argument("--count", type=int, default=1, help="Number of proxies to create (default: 1)")
+    parser.add_argument("--count", type=int, help="Number of proxies to create or use")
     parser.add_argument("--config", help="Configuration file path")
+    parser.add_argument("--bind", help="Bind address for local SOCKS proxies")
+    parser.add_argument("--start-port", type=int, help="Starting port for local SOCKS proxies")
 
     return parser
 
@@ -653,6 +1721,7 @@ def show_help_message() -> None:
     print("  create    Create new proxy endpoints")
     print("  list      List all proxy endpoints")
     print("  test      Test proxy endpoints and show IP addresses")
+    print("  socks     Start local SOCKS proxy server(s)")
     print("  cleanup   Delete all proxy endpoints")
     print("  help      Show detailed help")
     print("\nExamples:")
@@ -660,6 +1729,7 @@ def show_help_message() -> None:
     print("  python3 flareprox.py create --count 2")
     print("  python3 flareprox.py test")
     print("  python3 flareprox.py test --url https://httpbin.org/ip")
+    print("  python3 flareprox.py socks --bind 127.0.0.1")
 
 
 def show_config_help() -> None:
@@ -766,7 +1836,21 @@ def main():
 
     try:
         if args.command == "create":
-            flareprox.create_proxies(args.count)
+            count = args.count if args.count and args.count > 0 else 1
+            results = flareprox.create_proxies(count)
+
+            if args.bind:
+                created_endpoints = results.get("created", [])
+                if created_endpoints:
+                    auto_random = flareprox.client_settings.get("auto_random_ports", True)
+                    if args.start_port is not None:
+                        auto_random = False
+                    flareprox.run_socks_servers(
+                        created_endpoints,
+                        bind_host=args.bind,
+                        base_port=args.start_port,
+                        auto_random=auto_random
+                    )
 
         elif args.command == "list":
             flareprox.list_proxies()
@@ -775,7 +1859,26 @@ def main():
             if args.url:
                 flareprox.test_proxies(args.url, args.method)
             else:
-                flareprox.test_proxies()  # Use default httpbin.org/ip
+                flareprox.test_proxies()
+
+        elif args.command == "socks":
+            limit = args.count if args.count and args.count > 0 else None
+            endpoints = flareprox._select_endpoints_for_client(limit)
+
+            if not endpoints:
+                print("No proxy endpoints available. Create some first.")
+                return
+
+            auto_random = flareprox.client_settings.get("auto_random_ports", True)
+            if args.start_port is not None:
+                auto_random = False
+
+            flareprox.run_socks_servers(
+                endpoints,
+                bind_host=args.bind,
+                base_port=args.start_port,
+                auto_random=auto_random
+            )
 
         elif args.command == "cleanup":
             confirm = input("Delete ALL FlareProx endpoints? (y/N): ")

--- a/gcp_relay.py
+++ b/gcp_relay.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+import argparse
+import asyncio
+import contextlib
+import json
+import os
+import signal
+from typing import Optional
+
+from websockets.legacy.server import Serve, WebSocketServerProtocol, serve
+
+
+class RelayServer:
+    def __init__(self, host: str, port: int, password: str, auth_token: Optional[str], handshake_timeout: float) -> None:
+        self.host = host
+        self.port = port
+        self.password = password
+        self.auth_token = auth_token or ""
+        self.handshake_timeout = handshake_timeout
+        self._server: Optional[Serve] = None
+
+    async def start(self) -> None:
+        self._server = await serve(
+            self._handle_client,
+            self.host,
+            self.port,
+            process_request=self._process_request,
+            max_size=None,
+        )
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    async def _process_request(self, path, request_headers):
+        if self.auth_token:
+            header = request_headers.get("Authorization", "")
+            if header != self.auth_token:
+                body = b"Unauthorized"
+                return (401, [("Content-Type", "text/plain"), ("Content-Length", str(len(body)))], body)
+        return None
+
+    async def _handle_client(self, websocket: WebSocketServerProtocol, path: str = "") -> None:
+        reader = None
+        writer: Optional[asyncio.StreamWriter] = None
+
+        try:
+            raw = await asyncio.wait_for(websocket.recv(), timeout=self.handshake_timeout)
+        except Exception:
+            await websocket.close(code=4000, reason="Handshake timeout")
+            return
+
+        if isinstance(raw, (bytes, bytearray, memoryview)):
+            await websocket.close(code=4001, reason="Invalid handshake payload")
+            return
+
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            await websocket.close(code=4002, reason="Invalid handshake JSON")
+            return
+
+        if not isinstance(payload, dict):
+            await websocket.close(code=4003, reason="Invalid handshake format")
+            return
+
+        hostname = payload.get("hostname")
+        port = payload.get("port")
+        password = payload.get("password")
+
+        if not hostname or not isinstance(hostname, str):
+            await websocket.send(json.dumps({"type": "error", "code": "invalid-target", "message": "Missing hostname"}))
+            await websocket.close(code=4004, reason="Missing hostname")
+            return
+
+        if not isinstance(port, int) or port < 1 or port > 65535:
+            await websocket.send(json.dumps({"type": "error", "code": "invalid-target", "message": "Invalid port"}))
+            await websocket.close(code=4005, reason="Invalid port")
+            return
+
+        if self.password and password != self.password:
+            await websocket.send(json.dumps({"type": "error", "code": "auth-failed", "message": "Invalid credentials"}))
+            await websocket.close(code=4006, reason="Auth failed")
+            return
+
+        try:
+            reader, writer = await asyncio.open_connection(hostname, port)
+        except Exception as exc:
+            await websocket.send(json.dumps({
+                "type": "error",
+                "code": "connect-failed",
+                "message": str(exc) or "Failed to connect upstream"
+            }))
+            await websocket.close(code=4007, reason="Upstream connect failed")
+            return
+
+        await websocket.send(json.dumps({"type": "ready"}))
+
+        async def ws_to_tcp() -> None:
+            try:
+                async for message in websocket:
+                    if isinstance(message, str):
+                        writer.write(message.encode("utf-8"))
+                    else:
+                        writer.write(message)
+                    await writer.drain()
+            finally:
+                if writer is not None:
+                    writer.close()
+                    with contextlib.suppress(Exception):
+                        await writer.wait_closed()
+
+        async def tcp_to_ws() -> None:
+            try:
+                while True:
+                    data = await reader.read(65536)
+                    if not data:
+                        break
+                    await websocket.send(data)
+            finally:
+                await websocket.close()
+
+        tasks = [asyncio.create_task(ws_to_tcp()), asyncio.create_task(tcp_to_ws())]
+        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+
+        for task in done:
+            with contextlib.suppress(Exception):
+                task.result()
+
+    async def run_forever(self) -> None:
+        await self.start()
+        stop_event = asyncio.Event()
+
+        def _stop(*_: object) -> None:
+            stop_event.set()
+
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, _stop)
+
+        await stop_event.wait()
+        await self.close()
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="FlareProx relay server")
+    parser.add_argument("--host", default="0.0.0.0", help="Bind host")
+    parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", 8080)), help="Bind port")
+    parser.add_argument("--password", default=os.environ.get("FLAREPROX_RELAY_PASSWORD", ""), help="Shared SOCKS password")
+    parser.add_argument("--auth-token", default=os.environ.get("FLAREPROX_RELAY_TOKEN", ""), help="Authorization token to expect in the Authorization header")
+    parser.add_argument("--handshake-timeout", type=float, default=float(os.environ.get("FLAREPROX_HANDSHAKE_TIMEOUT", "5")), help="Seconds to wait for handshake before closing")
+
+    args = parser.parse_args()
+
+    server = RelayServer(
+        host=args.host,
+        port=args.port,
+        password=args.password,
+        auth_token=args.auth_token,
+        handshake_timeout=args.handshake_timeout,
+    )
+
+    await server.run_forever()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.28.0
+websockets>=11.0.3


### PR DESCRIPTION
Thanks for giving this oversized diff a look—it's bigger than I'd want in one shot, but I spent today wiring, testing, and reviewing it end-to-end so it lands as a clean package.

- Introduced a full SOCKS5 client mode (the original HTTP path stays intact) with IPv4-only DoH caching and relay-aware retries. Twenty hours ago we only had a fragile HTTP shim; now targets that Cloudflare blocks automatically pivot to the relay path (still well within free tier provider limits)
- Added the deployable GCP Cloud Run relay script plus setup notes so maintainers can drop in a fallback on Cloud Run's always-free tier. The same container image and config ports cleanly to other zero-cost hosts (Azure Container Apps, Koyeb, Render, Railway, et al.) when a different region or provider helps.
- Persisted worker/client defaults back into `flareprox.json` and pulled in the `websockets` dependency so fresh environments stop failing on missing secrets or modules.

Net result: everything still runs entirely on free-tier resources, but the client now ships with a proper SOCKS proxy mode and a tested relay escape hatch that leverages any alternate provider that can run a `python:3.11-slim` Dockerfile when encountering CF CDN blocks.
